### PR TITLE
Adiciona plano de estudos para iOS Application Security

### DIFF
--- a/ios/ios-security.md
+++ b/ios/ios-security.md
@@ -2,69 +2,85 @@
 
 Este plano foi criado a partir da junção de referências teóricas como artigos, tutoriais e partes específicas de livros. Enquanto os artigos e tutoriais naturalmente podem envolver a aplicação prática do conteúdo estudado, parte do consumo, principalmente do conteúdo em livros, pode levar a uma experiência de estudo mais próxima da teórica. Ao se encontrar nestas situações, uma recomendação pode ser a utilização de ferramentas de estudo que visem documentar e facilitar a recuperação do conteúdo posteriormente, assim como a aplicação das técnicas em aplicações que você já possa ter desenvolvido previamente.
 
+Este plano de estudos tem seus primeiros materiais selecionados referindo-se a habilidades que envolvem o suporte a uma experiência de utilização segura das aplicações iOS, mas não se limita a este contexto. Ao final do plano você também terá estudado sobre as possíveis vulnerabilidades que podem comprometer a segurança das aplicações iOS dada a natureza da implantação das mesmas com seus binários residindo em dispositivos controlados por terceiros, bem como as possíveis estratégias de defesa que possibilitam um desenvolvimento seguro. 
+
 ## Passos do plano em si
 
-### iOS Application Security
+1. Título do plano
 
-1. Motivação:
+iOS Application Security
 
-Smartphones são atualmente os dispositivos mais usados pelo público ao consumir o conteúdo disponível na rede mundial de computadores. Seja através das versões móveis de navegadores de internet ou de aplicações nativas, as pessoas estão interagindo através deles para se informar, comunicar e consumir produtos e serviços de diversas empresas que desenvolvem aplicações. A participação da plataforma iOS nesse mercado é, como esperado, expressiva, e portanto, com a união de um número massivo de pessoas consumindo e produzindo informação através dela, é natural que crackers sejam atraídos pela possibilidade de exploração de vulnerabilidades na plataforma, em especial pela natureza da distribuição de aplicações nativas. Sendo assim é de fundamental importância que pessoas desenvolvedoras de aplicativos iOS compreendam essas possíveis brechas de segurança e estejam aptas a desenvolver estratégias defensivas para oferecer uma boa e segura experiência de utilização ao usuário.
+2. Descrição do motivo que explica a importância do plano:
 
-2. Objetivo de Aprendizagem:
+Smartphones são atualmente os dispositivos mais usados pelo público ao consumir o conteúdo disponível na rede mundial de computadores. Seja através das versões móveis de navegadores de internet ou de aplicações nativas, as pessoas estão interagindo através deles para se informar, comunicar e consumir produtos e serviços de diversas empresas que desenvolvem suas aplicações. A participação da plataforma iOS nesse mercado é, como esperado, expressiva, e portanto, com a união de um número massivo de pessoas consumindo e produzindo informação através dela, é natural que crackers sejam atraídos pela possibilidade de exploração de vulnerabilidades na plataforma, em especial pela natureza da distribuição de aplicações nativas. Sendo assim é de fundamental importância que pessoas desenvolvedoras de aplicativos iOS compreendam essas possíveis brechas de segurança e estejam aptas a desenvolver estratégias defensivas para oferecer uma boa e segura experiência de utilização ao usuário.
+
+3. Um objetivo de aprendizagem conectado com um determinado nível da taxonomia de bloom que deixe claro onde a pessoa pode chegar caso ela siga o plano:
 
 O objetivo deste plano de estudos é capacitar a pessoa a desenvolver experiências de uso seguras em aplicações iOS entendendo os detalhes do modelo de segurança da plataforma e as estratégias de defesa que visam mitigar os possíveis problemas e vulnerabilidades de segurança.
 
-3. Pré-requisitos:
+4. Pré-requisitos necessários para seguir o plano:
 
 * Proficiência no desenvolvimento de aplicações para a plataforma iOS.
 * Conhecimento sobre a linguagem de programação Swift.
 * Algum conhecimento sobre a linguagem de programação Objective-C.
 
-4.  Lista de temas que serão abordados no plano, com referências e objetivos de aprendizagem específicos:
+5.  Lista de temas que serão abordados no plano, com referências e objetivos de aprendizagem específicos:
 
-* Quanto à usabilidade das aplicações
-    * Storage seguro e criptografia de dados
-        * Referências:
-            * [Basic iOS Security: Keychain and Hashing - Kodeco Tutorial](https://www.kodeco.com/129-basic-ios-security-keychain-and-hashing)
-            * [Part IV: Keeping Data Safe - iOS Application Security - Book Chapter](https://learning.oreilly.com/library/view/ios-application-security/9781457198830/part04.html)
-        * Objetivos de Aprendizagem:
-            * Entender as vulnerabilidades quanto à persistência de informações sensíveis
-            * Aplicar técnicas que evitem a exposição de informações sensíveis
+* Storage seguro e criptografia de dados
+    * Habilidades específicas:
+        * Entender as vulnerabilidades quanto à persistência de informações sensíveis
+        * Aplicar técnicas que evitem a exposição de informações sensíveis
+    * Referências:
+        * Basic iOS Security: Keychain and Hashing - Kodeco Tutorial
+            * https://www.kodeco.com/129-basic-ios-security-keychain-and-hashing
+        * Part IV: Keeping Data Safe - iOS Application Security - Book Chapter
+            * https://learning.oreilly.com/library/view/ios-application-security/9781457198830/part04.html
+    
+* Componentes de alto nível para autenticação
+    * Habilidades específicas:
+        * Entender as vulnerabilidades quanto à persistência de informações sensíveis
+        * Aplicar técnicas que evitem a exposição de informações sensíveis
+        * Utilizar componentes de alto nível que suportem uma boa experiência ao lidar com dados sensíveis do usuário
+        * Utilizar componentes de alto nível que suportem uma maior confiabilidade na autenticação dos usuários
+    * Referências:
+        * iOS 12 Password Tools: Improving User Security and Experience - Kodeco Tutorial
+            * https://www.kodeco.com/7162-ios-12-password-tools-improving-user-security-and-experience
+        * How to secure iOS User Data: The Keychain and Biometrics - FaceID and TouchID - Kodeco Tutorial
+            * https://www.kodeco.com/236-how-to-secure-ios-user-data-the-keychain-and-biometrics-face-id-or-touch-id
+    
 
-    * Componentes de alto nível para autenticação
-        * Referências:
-            * [iOS 12 Password Tools: Improving User Security and Experience - Kodeco Tutorial](https://www.kodeco.com/7162-ios-12-password-tools-improving-user-security-and-experience)
-            * [How to secure iOS User Data: The Keychain and Biometrics - FaceID and TouchID - Kodeco Tutorial](https://www.kodeco.com/236-how-to-secure-ios-user-data-the-keychain-and-biometrics-face-id-or-touch-id)
-        * Objetivos de aprendizagem:
-            * Entender as vulnerabilidades quanto à persistência de informações sensíveis
-            * Aplicar técnicas que evitem a exposição de informações sensíveis
-            * Utilizar componentes de alto nível que suportem uma boa experiência ao lidar com dados sensíveis do usuário
-            * Utilizar componentes de alto nível que suportem uma maior confiabilidade na autenticação dos usuários
+* Sobre o contexto de segurança na distribuição de aplicações iOS
+    * Habilidades específicas:
+        * Entender o contexto de segurança dada a natureza de aplicações móveis
+        * Entender o modelo de segurança de aplicações iOS
+    * Referências:
+        * Chapter 1 - Mobile Application (In)Security - The Mobile Application Hacker's Handbook - Book Chapter
+            * https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c01.xhtml
+        * Chapter 2 - Analysing iOS Application - The Mobile Application Hacker's Handbook - Book Chapter
+            * https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c02.xhtml
+    
 
-* Quanto às defesas a possíveis atacantes de uma aplicação
-    * Sobre o contexto de segurança na distribuição de aplicações iOS
-        * Referências:
-            * [Chapter 1 - Mobile Application (In)Security - The Mobile Application Hacker's Handbook - Book Chapter](https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c01.xhtml)
-            * [Chapter 2 - Analysing iOS Application - The Mobile Application Hacker's Handbook - Book Chapter](https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c02.xhtml)
-        * Objetivos de Aprendizagem:
-            * Entender o contexto de segurança dada a natureza de aplicações móveis
-            * Entender o modelo de segurança de aplicações iOS
+* Sobre como é possível conduzir ataques e testes à segurança de uma aplicação iOS
+    * Habilidades específicas:
+        * Entender as estratégias de ataque à aplicações iOS
+        * Entender as estratégias de testes/avaliação de segurança de aplicações iOS
+    * Referências:
+        * Chapter 3 - Attacking iOS Applications - The Mobile Application Hacker's Handbook - Book Chapter
+            * https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c03.xhtml
+        * Chapter 4 - Identifying iOS Implementation Insecurities -  The Mobile Application Hacker's Handbook - Book Chapter
+            * https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c04.xhtml
+        * Part II - Security Testing - iOS Application Security - Book Chapter
+            * https://learning.oreilly.com/library/view/ios-application-security/9781457198830/part02.html
+    
 
-    * Sobre como é possível conduzir ataques e testes à segurança de uma aplicação iOS
-        * Referências:
-            * [Chapter 3 - Attacking iOS Applications - The Mobile Application Hacker's Handbook - Book Chapter](https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c03.xhtml)
-            * [Chapter 4 - Identifying iOS Implementation Insecurities -  The Mobile Application Hacker's Handbook - Book Chapter](https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c04.xhtml)
-            * [Part II - Security Testing - iOS Application Security - Book Chapter](https://learning.oreilly.com/library/view/ios-application-security/9781457198830/part02.html)
-        * Objetivos de Aprendizagem:
-            * Entender as estratégias de ataque à aplicações iOS
-            * Entender as estratégias de testes/avaliação de segurança de aplicações iOS
+* Sobre as estratégias de defesa à exploração de vulnerabilidades de segurança
+    * Habilidades específicas:
+        * Entender as estratégias de defesa aos possíveis ataques à aplicações iOS
+    * Referências:
+        * Chapter 5 - Writing Secure iOS Applications - The Mobile Application Hacker's Handbook - Book Chapter
+            * https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c05.xhtml
+    
 
-    * Sobre as estratégias de defesa à exploração de vulnerabilidades de segurança
-        * Referências:
-            * [Chapter 5 - Writing Secure iOS Applications - The Mobile Application Hacker's Handbook - Book Chapter](https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c05.xhtml)
-        * Objetivos de Aprendizagem:
-            * Entender as estratégias de defesa aos possíveis ataques à aplicações iOS
-
-5. Palavras-chave:
+6. Palavras-chave:
     
     iOS, XCode, Cocoa, Cocoa Touch Framework, App Security, iOS Security, Data Protection, Keychain, Hashing, Encryption, Biometrics, FaceID, TouchID, Password Tools, Hacking, App Sandbox, Binary Protection, Jailbreaks, Anti-Debugging Protection, Obfuscation 

--- a/ios/ios-security.md
+++ b/ios/ios-security.md
@@ -4,6 +4,8 @@ Este plano foi criado a partir da junção de referências teóricas como artigo
 
 ## Passos do plano em si
 
+### iOS Application Security
+
 1. Motivação:
 
 Smartphones são atualmente os dispositivos mais usados pelo público ao consumir o conteúdo disponível na rede mundial de computadores. Seja através das versões móveis de navegadores de internet ou de aplicações nativas, as pessoas estão interagindo através deles para se informar, comunicar e consumir produtos e serviços de diversas empresas que desenvolvem aplicações. A participação da plataforma iOS nesse mercado é, como esperado, expressiva, e portanto, com a união de um número massivo de pessoas consumindo e produzindo informação através dela, é natural que crackers sejam atraídos pela possibilidade de exploração de vulnerabilidades na plataforma, em especial pela natureza da distribuição de aplicações nativas. Sendo assim é de fundamental importância que pessoas desenvolvedoras de aplicativos iOS compreendam essas possíveis brechas de segurança e estejam aptas a desenvolver estratégias defensivas para oferecer uma boa e segura experiência de utilização ao usuário.

--- a/ios/ios-security.md
+++ b/ios/ios-security.md
@@ -1,0 +1,68 @@
+## Como usar este plano?
+
+Este plano foi criado a partir da junção de referências teóricas como artigos, tutoriais e partes específicas de livros. Enquanto os artigos e tutoriais naturalmente podem envolver a aplicação prática do conteúdo estudado, parte do consumo, principalmente do conteúdo em livros, pode levar a uma experiência de estudo mais próxima da teórica. Ao se encontrar nestas situações, uma recomendação pode ser a utilização de ferramentas de estudo que visem documentar e facilitar a recuperação do conteúdo posteriormente, assim como a aplicação das técnicas em aplicações que você já possa ter desenvolvido previamente.
+
+## Passos do plano em si
+
+1. Motivação:
+
+Smartphones são atualmente os dispositivos mais usados pelo público ao consumir o conteúdo disponível na rede mundial de computadores. Seja através das versões móveis de navegadores de internet ou de aplicações nativas, as pessoas estão interagindo através deles para se informar, comunicar e consumir produtos e serviços de diversas empresas que desenvolvem aplicações. A participação da plataforma iOS nesse mercado é, como esperado, expressiva, e portanto, com a união de um número massivo de pessoas consumindo e produzindo informação através dela, é natural que crackers sejam atraídos pela possibilidade de exploração de vulnerabilidades na plataforma, em especial pela natureza da distribuição de aplicações nativas. Sendo assim é de fundamental importância que pessoas desenvolvedoras de aplicativos iOS compreendam essas possíveis brechas de segurança e estejam aptas a desenvolver estratégias defensivas para oferecer uma boa e segura experiência de utilização ao usuário.
+
+2. Objetivo de Aprendizagem:
+
+O objetivo deste plano de estudos é capacitar a pessoa a desenvolver experiências de uso seguras em aplicações iOS entendendo os detalhes do modelo de segurança da plataforma e as estratégias de defesa que visam mitigar os possíveis problemas e vulnerabilidades de segurança.
+
+3. Pré-requisitos:
+
+* Proficiência no desenvolvimento de aplicações para a plataforma iOS.
+* Conhecimento sobre a linguagem de programação Swift.
+* Algum conhecimento sobre a linguagem de programação Objective-C.
+
+4.  Lista de temas que serão abordados no plano, com referências e objetivos de aprendizagem específicos:
+
+* Quanto à usabilidade das aplicações
+    * Storage seguro e criptografia de dados
+        * Referências:
+            * [Basic iOS Security: Keychain and Hashing - Kodeco Tutorial](https://www.kodeco.com/129-basic-ios-security-keychain-and-hashing)
+            * [Part IV: Keeping Data Safe - iOS Application Security - Book Chapter](https://learning.oreilly.com/library/view/ios-application-security/9781457198830/part04.html)
+        * Objetivos de Aprendizagem:
+            * Entender as vulnerabilidades quanto à persistência de informações sensíveis
+            * Aplicar técnicas que evitem a exposição de informações sensíveis
+
+    * Componentes de alto nível para autenticação
+        * Referências:
+            * [iOS 12 Password Tools: Improving User Security and Experience - Kodeco Tutorial](https://www.kodeco.com/7162-ios-12-password-tools-improving-user-security-and-experience)
+            * [How to secure iOS User Data: The Keychain and Biometrics - FaceID and TouchID - Kodeco Tutorial](https://www.kodeco.com/236-how-to-secure-ios-user-data-the-keychain-and-biometrics-face-id-or-touch-id)
+        * Objetivos de aprendizagem:
+            * Entender as vulnerabilidades quanto à persistência de informações sensíveis
+            * Aplicar técnicas que evitem a exposição de informações sensíveis
+            * Utilizar componentes de alto nível que suportem uma boa experiência ao lidar com dados sensíveis do usuário
+            * Utilizar componentes de alto nível que suportem uma maior confiabilidade na autenticação dos usuários
+
+* Quanto às defesas a possíveis atacantes de uma aplicação
+    * Sobre o contexto de segurança na distribuição de aplicações iOS
+        * Referências:
+            * [Chapter 1 - Mobile Application (In)Security - The Mobile Application Hacker's Handbook - Book Chapter](https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c01.xhtml)
+            * [Chapter 2 - Analysing iOS Application - The Mobile Application Hacker's Handbook - Book Chapter](https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c02.xhtml)
+        * Objetivos de Aprendizagem:
+            * Entender o contexto de segurança dada a natureza de aplicações móveis
+            * Entender o modelo de segurança de aplicações iOS
+
+    * Sobre como é possível conduzir ataques e testes à segurança de uma aplicação iOS
+        * Referências:
+            * [Chapter 3 - Attacking iOS Applications - The Mobile Application Hacker's Handbook - Book Chapter](https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c03.xhtml)
+            * [Chapter 4 - Identifying iOS Implementation Insecurities -  The Mobile Application Hacker's Handbook - Book Chapter](https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c04.xhtml)
+            * [Part II - Security Testing - iOS Application Security - Book Chapter](https://learning.oreilly.com/library/view/ios-application-security/9781457198830/part02.html)
+        * Objetivos de Aprendizagem:
+            * Entender as estratégias de ataque à aplicações iOS
+            * Entender as estratégias de testes/avaliação de segurança de aplicações iOS
+
+    * Sobre as estratégias de defesa à exploração de vulnerabilidades de segurança
+        * Referências:
+            * [Chapter 5 - Writing Secure iOS Applications - The Mobile Application Hacker's Handbook - Book Chapter](https://learning.oreilly.com/library/view/the-mobile-application/9781118958513/c05.xhtml)
+        * Objetivos de Aprendizagem:
+            * Entender as estratégias de defesa aos possíveis ataques à aplicações iOS
+
+5. Palavras-chave:
+    
+    iOS, XCode, Cocoa, Cocoa Touch Framework, App Security, iOS Security, Data Protection, Keychain, Hashing, Encryption, Biometrics, FaceID, TouchID, Password Tools, Hacking, App Sandbox, Binary Protection, Jailbreaks, Anti-Debugging Protection, Obfuscation 


### PR DESCRIPTION
Este PR adiciona uma proposta de plano de estudos para iOS App Security, em linha com o item **Application Security** da colmeia da Zup.

O plano indica materiais educacionais das plataformas Kodeco.com e Oreilly Learning.